### PR TITLE
Update language bindings and PQC Dilithium integration

### DIFF
--- a/java/shared/java/org/signal/libsignal/protocol/IdentityKeyPair.java
+++ b/java/shared/java/org/signal/libsignal/protocol/IdentityKeyPair.java
@@ -42,6 +42,24 @@ public class IdentityKeyPair {
     return new IdentityKeyPair(new IdentityKey(publicKey), privateKey);
   }
 
+  /**
+   * Generate a new Dilithium2 identity key pair.
+   * 
+   * Note: This creates an IdentityKeyPair that contains PQC keys but wraps them
+   * in ECPrivateKey for compatibility. Future versions may use a more generic approach.
+   * 
+   * @return A new IdentityKeyPair with Dilithium2 keys
+   */
+  public static IdentityKeyPair generateDilithium2() {
+    long[] tuple = Native.IdentityKeyPair_GenerateDilithium2();
+    long publicKeyHandle = tuple[0];
+    long privateKeyHandle = tuple[1];
+
+    IdentityKey identityKey = new IdentityKey(publicKeyHandle);
+    ECPrivateKey privateKey = new ECPrivateKey(privateKeyHandle);
+    return new IdentityKeyPair(identityKey, privateKey);
+  }
+
   public IdentityKey getPublicKey() {
     return publicKey;
   }

--- a/node/Native.d.ts
+++ b/node/Native.d.ts
@@ -338,6 +338,7 @@ export function HsmEnclaveClient_New(trustedPublicKey: Uint8Array, trustedCodeHa
 export function HttpRequest_add_header(request: Wrapper<HttpRequest>, name: string, value: string): void;
 export function HttpRequest_new(method: string, path: string, bodyAsSlice: Uint8Array | null): HttpRequest;
 export function IdentityKeyPair_Deserialize(buffer: Uint8Array): {publicKey:PublicKey,privateKey:PrivateKey};
+export function IdentityKeyPair_GenerateDilithium2(): {publicKey:PublicKey,privateKey:PrivateKey};
 export function IdentityKeyPair_Serialize(publicKey: Wrapper<PublicKey>, privateKey: Wrapper<PrivateKey>): Uint8Array;
 export function IdentityKeyPair_SignAlternateIdentity(publicKey: Wrapper<PublicKey>, privateKey: Wrapper<PrivateKey>, otherIdentity: Wrapper<PublicKey>): Uint8Array;
 export function IdentityKey_VerifyAlternateIdentity(publicKey: Wrapper<PublicKey>, otherIdentity: Wrapper<PublicKey>, signature: Uint8Array): boolean;
@@ -415,6 +416,7 @@ export function PreKeySignalMessage_Serialize(obj: Wrapper<PreKeySignalMessage>)
 export function PrivateKey_Agree(privateKey: Wrapper<PrivateKey>, publicKey: Wrapper<PublicKey>): Uint8Array;
 export function PrivateKey_Deserialize(data: Uint8Array): PrivateKey;
 export function PrivateKey_Generate(): PrivateKey;
+export function PrivateKey_GenerateDilithium2(): PrivateKey;
 export function PrivateKey_GetPublicKey(k: Wrapper<PrivateKey>): PublicKey;
 export function PrivateKey_HpkeOpen(sk: Wrapper<PrivateKey>, ciphertext: Uint8Array, info: Uint8Array, associatedData: Uint8Array): Uint8Array;
 export function PrivateKey_Serialize(obj: Wrapper<PrivateKey>): Uint8Array;

--- a/node/ts/EcKeys.ts
+++ b/node/ts/EcKeys.ts
@@ -84,6 +84,10 @@ export class PrivateKey {
     return new PrivateKey(Native.PrivateKey_Generate());
   }
 
+  static generateDilithium2(): PrivateKey {
+    return new PrivateKey(Native.PrivateKey_GenerateDilithium2());
+  }
+
   static deserialize(buf: Uint8Array): PrivateKey {
     return new PrivateKey(Native.PrivateKey_Deserialize(buf));
   }
@@ -139,6 +143,14 @@ export class IdentityKeyPair {
   static generate(): IdentityKeyPair {
     const privateKey = PrivateKey.generate();
     return new IdentityKeyPair(privateKey.getPublicKey(), privateKey);
+  }
+
+  static generateDilithium2(): IdentityKeyPair {
+    const { publicKey, privateKey } = Native.IdentityKeyPair_GenerateDilithium2();
+    return new IdentityKeyPair(
+      PublicKey._fromNativeHandle(publicKey),
+      PrivateKey._fromNativeHandle(privateKey)
+    );
   }
 
   static deserialize(buffer: Uint8Array): IdentityKeyPair {

--- a/rust/bridge/shared/src/protocol.rs
+++ b/rust/bridge/shared/src/protocol.rs
@@ -262,6 +262,25 @@ fn KyberKeyPair_GetSecretKey(key_pair: &KyberKeyPair) -> KyberSecretKey {
     key_pair.secret_key.clone()
 }
 
+// === PQC: Dilithium bridge functions ===
+#[bridge_fn(ffi = "privatekey_generate_dilithium2", node = "PrivateKey_GenerateDilithium2")]
+fn ECPrivateKey_GenerateDilithium2() -> Result<PrivateKey> {
+    Ok(PrivateKey::generate_dilithium2()?)
+}
+
+#[bridge_fn(ffi = "identitykeypair_generate_dilithium2", node = "IdentityKeyPair_GenerateDilithium2")]
+fn IdentityKeyPair_GenerateDilithium2() -> Result<(PublicKey, PrivateKey)> {
+    let mut rng = rand::rngs::OsRng;
+    let identity_key_pair = IdentityKeyPair::generate_dilithium(&mut rng);
+    Ok((identity_key_pair.identity_key().public_key(), identity_key_pair.private_key()))
+}
+
+#[bridge_fn(ffi = "identitykeypair_deserialize", node = "IdentityKeyPair_Deserialize")]
+fn IdentityKeyPair_Deserialize(data: &[u8]) -> Result<(PublicKey, PrivateKey)> {
+    let identity_key_pair = IdentityKeyPair::deserialize(data)?;
+    Ok((identity_key_pair.identity_key().public_key(), identity_key_pair.private_key()))
+}
+
 #[bridge_fn(ffi = "identitykeypair_serialize")]
 fn IdentityKeyPair_Serialize(public_key: &PublicKey, private_key: &PrivateKey) -> Vec<u8> {
     let identity_key_pair = IdentityKeyPair::new(IdentityKey::new(*public_key), *private_key);

--- a/rust/core/src/curve.rs
+++ b/rust/core/src/curve.rs
@@ -586,4 +586,82 @@ mod tests {
         let error = Box::new(error) as Box<dyn std::error::Error>;
         assert_matches!(error.downcast_ref(), Some(CurveError::BadKeyType(_)));
     }
+
+    #[cfg(test)]
+    fn benchmark_ec_operations() {
+        use std::time::Instant;
+        
+        let mut rng = OsRng.unwrap_err();
+        let message = b"Performance test message for signature benchmarking";
+        
+        // EC key generation benchmark
+        let start = Instant::now();
+        for _ in 0..100 {
+            let _ = KeyPair::generate(&mut rng);
+        }
+        let ec_keygen_time = start.elapsed();
+        println!("EC key generation (100 iterations): {:?}", ec_keygen_time);
+        
+        // EC signing benchmark
+        let ec_keypair = KeyPair::generate(&mut rng);
+        let start = Instant::now();
+        for _ in 0..100 {
+            let _ = ec_keypair.private_key.calculate_signature(message, &mut rng).unwrap();
+        }
+        let ec_sign_time = start.elapsed();
+        println!("EC signing (100 iterations): {:?}", ec_sign_time);
+        
+        // EC verification benchmark
+        let signature = ec_keypair.private_key.calculate_signature(message, &mut rng).unwrap();
+        let start = Instant::now();
+        for _ in 0..100 {
+            let _ = ec_keypair.public_key.verify_signature(message, &signature);
+        }
+        let ec_verify_time = start.elapsed();
+        println!("EC verification (100 iterations): {:?}", ec_verify_time);
+    }
+
+    #[cfg(test)]
+    fn benchmark_dilithium_operations() {
+        use std::time::Instant;
+        
+        let mut rng = OsRng.unwrap_err();
+        let message = b"Performance test message for signature benchmarking";
+        
+        // Dilithium key generation benchmark
+        let start = Instant::now();
+        for _ in 0..100 {
+            let _ = PrivateKey::generate_dilithium2().unwrap();
+        }
+        let dilithium_keygen_time = start.elapsed();
+        println!("Dilithium key generation (100 iterations): {:?}", dilithium_keygen_time);
+        
+        // Dilithium signing benchmark
+        let dilithium_private = PrivateKey::generate_dilithium2().unwrap();
+        let start = Instant::now();
+        for _ in 0..100 {
+            let _ = dilithium_private.calculate_signature(message, &mut rng).unwrap();
+        }
+        let dilithium_sign_time = start.elapsed();
+        println!("Dilithium signing (100 iterations): {:?}", dilithium_sign_time);
+        
+        // Dilithium verification benchmark
+        let dilithium_public = dilithium_private.public_key().unwrap();
+        let signature = dilithium_private.calculate_signature(message, &mut rng).unwrap();
+        let start = Instant::now();
+        for _ in 0..100 {
+            let _ = dilithium_public.verify_signature(message, &signature);
+        }
+        let dilithium_verify_time = start.elapsed();
+        println!("Dilithium verification (100 iterations): {:?}", dilithium_verify_time);
+    }
+
+    #[test]
+    fn test_performance_benchmarks() {
+        println!("\n=== Performance Benchmarks ===");
+        benchmark_ec_operations();
+        println!();
+        benchmark_dilithium_operations();
+        println!("=== End Benchmarks ===\n");
+    }
 }

--- a/rust/crypto/src/hpke.rs
+++ b/rust/crypto/src/hpke.rs
@@ -84,6 +84,9 @@ impl SimpleHpkeSender for libsignal_core::curve::PublicKey {
             libsignal_core::curve::KeyType::Djb => {
                 SignalHpkeCiphertextType::Base_X25519_HkdfSha256_Aes256Gcm
             }
+            libsignal_core::curve::KeyType::Dilithium2 => {
+                return Err(HpkeError::InvalidInput);
+            }
         };
 
         let hpke_key = HpkePublicKey::from(self.public_key_bytes());
@@ -141,6 +144,12 @@ impl SimpleHpkeReceiver for libsignal_core::curve::PrivateKey {
                 SignalHpkeCiphertextType::Base_X25519_HkdfSha256_Aes256Gcm,
                 libsignal_core::curve::KeyType::Djb,
             ) => {}
+            (
+                SignalHpkeCiphertextType::Base_X25519_HkdfSha256_Aes256Gcm,
+                libsignal_core::curve::KeyType::Dilithium2,
+            ) => {
+                return Err(HpkeError::InvalidInput);
+            }
         }
 
         let (encapsulated_secret, ciphertext) = ciphertext

--- a/rust/crypto/src/hpke/provider.rs
+++ b/rust/crypto/src/hpke/provider.rs
@@ -79,8 +79,10 @@ impl HpkeCrypto for CryptoProvider {
             KemAlgorithm::DhKem25519 => {}
             _ => return Err(HpkeError::UnknownKemAlgorithm),
         }
-        let pk =
-            PublicKey::from_djb_public_key_bytes(pk).map_err(|_| HpkeError::KemInvalidPublicKey)?;
+        // Create a DJB public key by prepending the key type byte and deserializing
+        let mut key_with_type = vec![0x05u8]; // DJB key type identifier
+        key_with_type.extend_from_slice(pk);
+        let pk = PublicKey::deserialize(&key_with_type).map_err(|_| HpkeError::KemInvalidPublicKey)?;
         let sk = PrivateKey::deserialize(sk).map_err(|_| HpkeError::KemInvalidSecretKey)?;
         Ok(sk
             .calculate_agreement(&pk)

--- a/rust/protocol/src/identity_key.rs
+++ b/rust/protocol/src/identity_key.rs
@@ -105,11 +105,14 @@ impl IdentityKeyPair {
     }
 
     /// Generate a random new Dilithium identity from randomness in `csprng`.
-    ///
-    /// NOTE: This is a stub. Actual Dilithium key generation must be implemented.
     pub fn generate_dilithium<R: CryptoRng + Rng>(_csprng: &mut R) -> Self {
-        // TODO: Implement Dilithium key generation
-        unimplemented!("Dilithium identity key generation not implemented yet");
+        let private_key = PrivateKey::generate_dilithium2().expect("Failed to generate Dilithium2 key");
+        let public_key = private_key.public_key().expect("Failed to get public key from Dilithium2 private key");
+        let identity_key = IdentityKey::new(public_key);
+        Self {
+            identity_key,
+            private_key,
+        }
     }
 
     /// Return the public identity of this user.
@@ -232,10 +235,13 @@ mod tests {
     }
 
     #[test]
-    #[ignore]
     fn test_generate_dilithium_identity_key_pair() {
-        // This test will fail until Dilithium key generation is implemented
-        let _dilithium_identity = IdentityKeyPair::generate_dilithium(&mut OsRng.unwrap_err());
+        use rand::rngs::OsRng;
+        use libsignal_core::curve::KeyType;
+        
+        let dilithium_identity = IdentityKeyPair::generate_dilithium(&mut OsRng.unwrap_err());
+        assert_eq!(dilithium_identity.private_key().key_type(), KeyType::Dilithium2);
+        assert_eq!(dilithium_identity.public_key().key_type(), KeyType::Dilithium2);
     }
 
     #[test]

--- a/rust/protocol/src/sealed_sender.rs
+++ b/rust/protocol/src/sealed_sender.rs
@@ -582,10 +582,11 @@ impl<'a> UnidentifiedSenderMessage<'a> {
                     ephemeral_public,
                 } = zerocopy::Ref::into_ref(prefix);
 
+                // Create a DJB public key by prepending the key type byte and deserializing
+                let mut key_with_type = vec![0x05u8]; // DJB key type identifier
+                key_with_type.extend_from_slice(ephemeral_public.as_slice());
                 Ok(Self::V2 {
-                    ephemeral_public: PublicKey::from_djb_public_key_bytes(
-                        ephemeral_public.as_slice(),
-                    )?,
+                    ephemeral_public: PublicKey::deserialize(&key_with_type)?,
                     encrypted_message_key,
                     authentication_tag: encrypted_authentication_tag,
                     encrypted_message,

--- a/swift/Sources/LibSignalClient/IdentityKey.swift
+++ b/swift/Sources/LibSignalClient/IdentityKey.swift
@@ -47,6 +47,19 @@ public struct IdentityKeyPair: Sendable {
         return IdentityKeyPair(publicKey: publicKey, privateKey: privateKey)
     }
 
+    public static func generateDilithium2() -> IdentityKeyPair {
+        var pubkeyPtr = SignalMutPointerPublicKey()
+        var privkeyPtr = SignalMutPointerPrivateKey()
+        
+        failOnError {
+            try checkError(signal_identitykeypair_generate_dilithium2(&privkeyPtr, &pubkeyPtr))
+        }
+
+        let publicKey = PublicKey(owned: NonNull(pubkeyPtr)!)
+        let privateKey = PrivateKey(owned: NonNull(privkeyPtr)!)
+        return IdentityKeyPair(publicKey: publicKey, privateKey: privateKey)
+    }
+
     public init<Bytes: ContiguousBytes>(bytes: Bytes) throws {
         var pubkeyPtr = SignalMutPointerPublicKey()
         var privkeyPtr = SignalMutPointerPrivateKey()

--- a/swift/Sources/LibSignalClient/PrivateKey.swift
+++ b/swift/Sources/LibSignalClient/PrivateKey.swift
@@ -24,6 +24,14 @@ public class PrivateKey: ClonableHandleOwner<SignalMutPointerPrivateKey>, @unche
         }
     }
 
+    public static func generateDilithium2() -> PrivateKey {
+        return failOnError {
+            try invokeFnReturningNativeHandle {
+                signal_privatekey_generate_dilithium2($0)
+            }
+        }
+    }
+
     override internal class func cloneNativeHandle(
         _ newHandle: inout SignalMutPointerPrivateKey,
         currentHandle: SignalConstPointerPrivateKey

--- a/swift/Sources/SignalFfi/signal_ffi.h
+++ b/swift/Sources/SignalFfi/signal_ffi.h
@@ -1755,6 +1755,8 @@ SignalFfiError *signal_identitykeypair_serialize(SignalOwnedBuffer *out, SignalC
 
 SignalFfiError *signal_identitykeypair_sign_alternate_identity(SignalOwnedBuffer *out, SignalConstPointerPublicKey public_key, SignalConstPointerPrivateKey private_key, SignalConstPointerPublicKey other_identity);
 
+SignalFfiError *signal_identitykeypair_generate_dilithium2(SignalMutPointerPrivateKey *private_key, SignalMutPointerPublicKey *public_key);
+
 SignalFfiError *signal_incremental_mac_calculate_chunk_size(uint32_t *out, uint32_t data_size);
 
 SignalFfiError *signal_incremental_mac_destroy(SignalMutPointerIncrementalMac p);
@@ -2000,6 +2002,8 @@ SignalFfiError *signal_privatekey_deserialize(SignalMutPointerPrivateKey *out, S
 SignalFfiError *signal_privatekey_destroy(SignalMutPointerPrivateKey p);
 
 SignalFfiError *signal_privatekey_generate(SignalMutPointerPrivateKey *out);
+
+SignalFfiError *signal_privatekey_generate_dilithium2(SignalMutPointerPrivateKey *out);
 
 SignalFfiError *signal_privatekey_get_public_key(SignalMutPointerPublicKey *out, SignalConstPointerPrivateKey k);
 


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Add Dilithium2 post-quantum cryptography support to Rust core, FFI bridge, and language bindings (Java, Swift, Node.js) to enable PQC identity key generation.

---

[Open in Web](https://cursor.com/agents?id=bc-ade59a72-e88d-40ef-8cab-23c1a6bdb139) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-ade59a72-e88d-40ef-8cab-23c1a6bdb139) • [Open Docs](https://docs.cursor.com/background-agent/web-and-mobile)